### PR TITLE
Add support for 1559

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-gas-estimation = { path = "../../gp-gas-estimation/gp-gas-estimation" }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.4" }
 
 [dev-dependencies]
 mockall = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+gas-estimation = { path = "../../gp-gas-estimation/gp-gas-estimation" }
 
 [dev-dependencies]
 mockall = "0.8"

--- a/src/gas_price_increase.rs
+++ b/src/gas_price_increase.rs
@@ -23,15 +23,19 @@ fn new_gas_price_estimate(
     if min_gas_price.cap() > max_gas_price {
         return None;
     }
-    if new_gas_price.cap() <= previous_gas_price.cap() {
+    if new_gas_price.cap() <= previous_gas_price.cap()
+        || new_gas_price.tip() <= previous_gas_price.tip()
+    {
         // Gas price has not increased.
         return None;
     }
     // Gas price could have increased but doesn't respect minimum increase so adjust it up.
-    let new_price = if min_gas_price.cap() >= new_gas_price.cap() {
-        min_gas_price
-    } else {
+    let new_price = if new_gas_price.cap() >= min_gas_price.cap()
+        && new_gas_price.tip() >= min_gas_price.tip()
+    {
         new_gas_price
+    } else {
+        min_gas_price
     };
 
     Some(new_price.limit_cap(max_gas_price))
@@ -335,7 +339,7 @@ mod tests {
             &[
                 eip1559_gas_price(0.0, 0.0, 1.0),
                 eip1559_gas_price(1.0, 0.5, 1.0),
-                eip1559_gas_price(2.0, 1.0, 1.0)
+                eip1559_gas_price(2.0, 2.0, 1.0)
             ]
         );
     }

--- a/src/gas_price_increase.rs
+++ b/src/gas_price_increase.rs
@@ -1,32 +1,40 @@
 //! Transactions with the same nonce must have a minimum gas price increase.
 
 use futures::stream::{Stream, StreamExt as _};
+use gas_estimation::GasPrice;
 
 /// openethereum requires that the gas price of the resubmitted transaction has increased by at
 /// least 12.5%.
 const MIN_GAS_PRICE_INCREASE_FACTOR: f64 = 1.125 * (1.0 + f64::EPSILON);
 
 /// The minimum gas price that allows a new transaction to replace an older one.
-pub fn minimum_increase(previous_gas_price: f64) -> f64 {
-    (previous_gas_price * MIN_GAS_PRICE_INCREASE_FACTOR).ceil()
+pub fn minimum_increase(previous_gas_price: GasPrice) -> GasPrice {
+    previous_gas_price
+        .bump_cap(MIN_GAS_PRICE_INCREASE_FACTOR)
+        .ceil_cap()
 }
 
 fn new_gas_price_estimate(
-    previous_gas_price: f64,
-    new_gas_price: f64,
+    previous_gas_price: GasPrice,
+    new_gas_price: GasPrice,
     max_gas_price: f64,
-) -> Option<f64> {
+) -> Option<GasPrice> {
     let min_gas_price = minimum_increase(previous_gas_price);
-    if min_gas_price > max_gas_price {
+    if min_gas_price.cap() > max_gas_price {
         return None;
     }
-    if new_gas_price <= previous_gas_price {
+    if new_gas_price.cap() <= previous_gas_price.cap() {
         // Gas price has not increased.
         return None;
     }
     // Gas price could have increased but doesn't respect minimum increase so adjust it up.
-    let new_price = min_gas_price.max(new_gas_price);
-    Some(new_price.min(max_gas_price))
+    let new_price = if min_gas_price.cap() >= new_gas_price.cap() {
+        min_gas_price
+    } else {
+        new_gas_price
+    };
+
+    Some(new_price.limit_cap(max_gas_price))
 }
 
 /// Adapt a stream of gas prices to only yield gas prices that respect the minimum gas price
@@ -34,15 +42,15 @@ fn new_gas_price_estimate(
 /// Panics if gas price is negative or not finite.
 pub fn enforce_minimum_increase_and_cap(
     gas_price_cap: f64,
-    stream: impl Stream<Item = f64>,
-) -> impl Stream<Item = f64> {
-    let mut last_used_gas_price = None;
+    stream: impl Stream<Item = GasPrice>,
+) -> impl Stream<Item = GasPrice> {
+    let mut last_used_gas_price = Default::default();
     stream.filter_map(move |gas_price| {
-        assert!(gas_price.is_finite() && gas_price >= 0.0);
+        assert!(gas_price.cap().is_finite() && gas_price.cap() >= 0.0);
         let gas_price = if let Some(previous) = last_used_gas_price {
             new_gas_price_estimate(previous, gas_price, gas_price_cap)
         } else {
-            Some(gas_price.min(gas_price_cap))
+            Some(gas_price.limit_cap(gas_price_cap))
         };
         if let Some(gas_price) = gas_price {
             last_used_gas_price = Some(gas_price);
@@ -55,42 +63,94 @@ pub fn enforce_minimum_increase_and_cap(
 mod tests {
     use super::*;
     use futures::FutureExt;
+    use gas_estimation::GasPrice;
+
+    fn legacy_gas_price(legacy: f64) -> GasPrice {
+        GasPrice {
+            legacy,
+            ..Default::default()
+        }
+    }
 
     #[test]
-    fn new_gas_price_estimate_() {
+    fn new_gas_price_estimate_legacy() {
         // new below previous
-        assert_eq!(new_gas_price_estimate(10.0, 0.0, 20.0), None);
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(10.0), legacy_gas_price(0.0), 20.0),
+            None
+        );
         //new equal to previous
-        assert_eq!(new_gas_price_estimate(10.0, 10.0, 20.0), None);
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(10.0), legacy_gas_price(10.0), 20.0),
+            None
+        );
         // between previous and min increase rounded up to min increase
-        assert_eq!(new_gas_price_estimate(10.0, 11.0, 20.0), Some(12.0));
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(10.0), legacy_gas_price(11.0), 20.0),
+            Some(legacy_gas_price(12.0))
+        );
         // between min increase and max stays same
-        assert_eq!(new_gas_price_estimate(10.0, 13.0, 20.0), Some(13.0));
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(10.0), legacy_gas_price(13.0), 20.0),
+            Some(legacy_gas_price(13.0))
+        );
         // larger than max stays max
-        assert_eq!(new_gas_price_estimate(10.0, 20.0, 20.0), Some(20.0));
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(10.0), legacy_gas_price(20.0), 20.0),
+            Some(legacy_gas_price(20.0))
+        );
         // cannot increase by min increase
-        assert_eq!(new_gas_price_estimate(19.0, 18.0, 20.0), None);
-        assert_eq!(new_gas_price_estimate(19.0, 19.0, 20.0), None);
-        assert_eq!(new_gas_price_estimate(19.0, 19.5, 20.0), None);
-        assert_eq!(new_gas_price_estimate(19.0, 20.0, 20.0), None);
-        assert_eq!(new_gas_price_estimate(19.0, 25.0, 20.0), None);
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(19.0), legacy_gas_price(18.0), 20.0),
+            None
+        );
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(19.0), legacy_gas_price(19.0), 20.0),
+            None
+        );
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(19.0), legacy_gas_price(19.5), 20.0),
+            None
+        );
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(19.0), legacy_gas_price(20.0), 20.0),
+            None
+        );
+        assert_eq!(
+            new_gas_price_estimate(legacy_gas_price(19.0), legacy_gas_price(25.0), 20.0),
+            None
+        );
     }
 
     #[test]
     #[allow(clippy::float_cmp)]
-    fn stream_enforces_minimum_increase() {
-        let input_stream = futures::stream::iter(vec![0.0, 1.0, 1.0, 2.0, 2.5, 0.5]);
+    fn stream_enforces_minimum_increase_legacy() {
+        let input_stream = futures::stream::iter(vec![
+            legacy_gas_price(0.0),
+            legacy_gas_price(1.0),
+            legacy_gas_price(1.0),
+            legacy_gas_price(2.0),
+            legacy_gas_price(2.5),
+            legacy_gas_price(0.5),
+        ]);
         let stream = enforce_minimum_increase_and_cap(2.0, input_stream);
         let result = stream.collect::<Vec<_>>().now_or_never().unwrap();
-        assert_eq!(result, &[0.0, 1.0, 2.0]);
+        assert_eq!(
+            result,
+            &[
+                legacy_gas_price(0.0),
+                legacy_gas_price(1.0),
+                legacy_gas_price(2.0)
+            ]
+        );
     }
 
     #[test]
     #[allow(clippy::float_cmp)]
-    fn stream_enforces_cap_on_first_item() {
-        let input_stream = futures::stream::iter(vec![1500.0]);
+    fn stream_enforces_cap_on_first_item_legacy() {
+        let input_stream = futures::stream::iter(vec![legacy_gas_price(1500.0)]);
         let stream = enforce_minimum_increase_and_cap(500.0, input_stream);
         let result = stream.collect::<Vec<_>>().now_or_never().unwrap();
-        assert_eq!(result, &[500.0]);
+        assert_eq!(result, &[legacy_gas_price(500.0)]);
     }
 }

--- a/src/gas_price_increase.rs
+++ b/src/gas_price_increase.rs
@@ -20,15 +20,15 @@ fn new_gas_price_estimate(
     max_gas_price: f64,
 ) -> Option<EstimatedGasPrice> {
     let min_gas_price = minimum_increase(previous_gas_price);
-    if min_gas_price.effective_gas_price() > max_gas_price {
+    if min_gas_price.cap() > max_gas_price {
         return None;
     }
-    if new_gas_price.effective_gas_price() <= previous_gas_price.effective_gas_price() {
+    if new_gas_price.cap() <= previous_gas_price.cap() {
         // Gas price has not increased.
         return None;
     }
     // Gas price could have increased but doesn't respect minimum increase so adjust it up.
-    let new_price = if min_gas_price.effective_gas_price() >= new_gas_price.effective_gas_price() {
+    let new_price = if min_gas_price.cap() >= new_gas_price.cap() {
         min_gas_price
     } else {
         new_gas_price

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use futures::{
     future::FutureExt as _,
     stream::{Stream, StreamExt as _},
 };
+use gas_estimation::GasPrice;
 use std::future::Future;
 
 /// Implementation agnostic abstraction over sending a specific ethereum transaction.
@@ -19,7 +20,7 @@ pub trait TransactionSending: Send {
     /// The result of sending the transaction.
     type Output: TransactionResult;
     /// Send the transaction.
-    async fn send(&self, gas_price: f64) -> Self::Output;
+    async fn send(&self, gas_price: GasPrice) -> Self::Output;
 }
 
 /// Trait that the result of sent transactions must implement.
@@ -53,7 +54,7 @@ pub enum RetryResult<TransactionResult, CancellationResult> {
 pub async fn retry<TransactionSender, CancellationSender>(
     transaction_sender: TransactionSender,
     cancel_after: impl Future<Output = CancellationSender>,
-    gas_price_stream: impl Stream<Item = f64>,
+    gas_price_stream: impl Stream<Item = GasPrice>,
 ) -> Option<RetryResult<TransactionSender::Output, CancellationSender::Output>>
 where
     TransactionSender: TransactionSending,
@@ -70,7 +71,7 @@ where
     // case because we do not know which transactions will complete or fail or in which order we
     // observe completion.
     let mut first_match = FirstMatchOrLast::new(|result: &RetryResult<_, _>| result.was_mined());
-    let mut last_used_gas_price = 0.0;
+    let mut last_used_gas_price = Default::default();
     let cancellation_sender = loop {
         // Use select_biased over select because it makes tests deterministic. for real use doesn't
         // matter because the futures will almost never become ready at the same time.
@@ -87,7 +88,7 @@ where
     // Need to do this so that compiler doesn't complain that first_match gets dropped first.
     let (cancellation_sender, first_match) = (cancellation_sender, first_match);
 
-    let never_submitted_solution = last_used_gas_price == 0.0;
+    let never_submitted_solution = last_used_gas_price == Default::default();
     if never_submitted_solution {
         return None;
     }
@@ -114,6 +115,13 @@ mod tests {
     use super::*;
     use futures::{future, stream};
 
+    fn legacy_gas_price(legacy: f64) -> GasPrice {
+        GasPrice {
+            legacy,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn nonce_error_ignored() {
         let mut transaction_sender = MockTransactionSending::new();
@@ -132,7 +140,11 @@ mod tests {
             future::ready(false).boxed()
         });
 
-        let result = retry(transaction_sender, cancel_after, stream::repeat(1.0));
+        let result = retry(
+            transaction_sender,
+            cancel_after,
+            stream::repeat(legacy_gas_price(1.0)),
+        );
         let result = result.now_or_never().unwrap();
         assert!(matches!(result, Some(RetryResult::Submitted(true))));
     }
@@ -163,7 +175,11 @@ mod tests {
         }
         .boxed();
 
-        let result = retry(transaction_sender, cancel_after, stream::repeat(1.0));
+        let result = retry(
+            transaction_sender,
+            cancel_after,
+            stream::repeat(legacy_gas_price(1.0)),
+        );
         let result = result.now_or_never().unwrap();
         assert!(matches!(result, Some(RetryResult::Submitted(true))));
     }
@@ -188,7 +204,11 @@ mod tests {
         }
         .boxed();
 
-        let result = retry(transaction_sender, cancel_after, stream::repeat(1.0));
+        let result = retry(
+            transaction_sender,
+            cancel_after,
+            stream::repeat(legacy_gas_price(1.0)),
+        );
         let result = result.now_or_never().unwrap();
         assert!(matches!(result, Some(RetryResult::Cancelled(true))));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use futures::{
     future::FutureExt as _,
     stream::{Stream, StreamExt as _},
 };
-use gas_estimation::GasPrice;
+use gas_estimation::EstimatedGasPrice;
 use std::future::Future;
 
 /// Implementation agnostic abstraction over sending a specific ethereum transaction.
@@ -20,7 +20,7 @@ pub trait TransactionSending: Send {
     /// The result of sending the transaction.
     type Output: TransactionResult;
     /// Send the transaction.
-    async fn send(&self, gas_price: GasPrice) -> Self::Output;
+    async fn send(&self, gas_price: EstimatedGasPrice) -> Self::Output;
 }
 
 /// Trait that the result of sent transactions must implement.
@@ -54,7 +54,7 @@ pub enum RetryResult<TransactionResult, CancellationResult> {
 pub async fn retry<TransactionSender, CancellationSender>(
     transaction_sender: TransactionSender,
     cancel_after: impl Future<Output = CancellationSender>,
-    gas_price_stream: impl Stream<Item = GasPrice>,
+    gas_price_stream: impl Stream<Item = EstimatedGasPrice>,
 ) -> Option<RetryResult<TransactionSender::Output, CancellationSender::Output>>
 where
     TransactionSender: TransactionSending,
@@ -115,8 +115,8 @@ mod tests {
     use super::*;
     use futures::{future, stream};
 
-    fn legacy_gas_price(legacy: f64) -> GasPrice {
-        GasPrice {
+    fn legacy_gas_price(legacy: f64) -> EstimatedGasPrice {
+        EstimatedGasPrice {
             legacy,
             ..Default::default()
         }


### PR DESCRIPTION
Previously, this code worked with legacy gas price only (single f64 value).
Now, it works with `gas_estimation::EstimatedGasPrice` struct which supports both legacy and eip1559 gas price. (had to add the dependency to the `gas_estimation crate`).

Related to PRs:
https://github.com/gnosis/gp-gas-estimation/pull/14
https://github.com/gnosis/ethcontract-rs/pull/638
https://github.com/gnosis/gp-v2-services/pull/1166
https://github.com/gnosis/gp-v2-services/issues/1056