### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
-gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.4" }
+gas-estimation = { git = "https://github.com/gnosis/gp-gas-estimation.git", tag = "v0.3.5" }
 
 [dev-dependencies]
 mockall = "0.8"


### PR DESCRIPTION
This PR aims to update dependencies:

ethabi
ethereum-types
primitive-types
web3 rust

This is needed since we need newest features from web3 rust dependency.

related to: https://github.com/gnosis/gp-gas-estimation/pull/18

Will be merged after v0.3.5 is created on gp-gas-estimation repo